### PR TITLE
Initial support for refresh tokens

### DIFF
--- a/app/src/main/java/com/indieweb/indigenous/model/User.java
+++ b/app/src/main/java/com/indieweb/indigenous/model/User.java
@@ -7,6 +7,7 @@ public class User {
     private String accountName;
     private String externalId;
     private String accessToken;
+    private String refreshToken;
     private String microsubEndpoint;
     private String micropubEndpoint;
     private String micropubMediaEndpoint;
@@ -55,6 +56,14 @@ public class User {
 
     public void setAccessToken(String accessToken) {
         this.accessToken = accessToken;
+    }
+
+    public String getRefreshToken() {
+        return refreshToken;
+    }
+
+    public void setRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 
     public String getExternalId() {

--- a/app/src/main/java/com/indieweb/indigenous/users/Accounts.java
+++ b/app/src/main/java/com/indieweb/indigenous/users/Accounts.java
@@ -185,6 +185,7 @@ public class Accounts {
             }
 
             user.setAccessToken(token);
+            user.setRefreshToken(accountManager.getUserData(a, "refresh_token"));
             user.setAccountType(INDIEWEB_ACCOUNT_TYPE);
             user.setExternalId(accountManager.getUserData(a, "external_id"));
             user.setAvatar(accountManager.getUserData(a, "author_avatar"));

--- a/app/src/main/java/com/indieweb/indigenous/users/AuthActivity.java
+++ b/app/src/main/java/com/indieweb/indigenous/users/AuthActivity.java
@@ -59,7 +59,7 @@ public class AuthActivity extends AccountAuthenticatorActivity implements Volley
     public final static String MASTODON_TOKEN_TYPE = "Mastodon";
     public final static String PLEROMA_ACCOUNT_TYPE = "Pleroma";
     public final static String PLEROMA_TOKEN_TYPE = "Pleroma";
-    final String ClientId = "https://indiepass.app/";
+    public final static String ClientId = "https://indiepass.app/";
     final String RedirectUri = "https://indiepass.app/android-callback";
     protected VolleyRequestListener volleyRequestListener;
     String accountType = "indieweb";
@@ -534,6 +534,7 @@ public class AuthActivity extends AccountAuthenticatorActivity implements Volley
                     public void onResponse(String response) {
 
                         String accessToken = "";
+                        String refreshToken = "";
                         String errorMessage = "";
                         boolean accessTokenFound = false;
 
@@ -541,6 +542,7 @@ public class AuthActivity extends AccountAuthenticatorActivity implements Volley
                             JSONObject indieAuthResponse = new JSONObject(response);
                             accessToken = indieAuthResponse.getString("access_token");
                             accessTokenFound = true;
+                            refreshToken = indieAuthResponse.optString("refresh_token");
 
                             // Check the profile key.
                             if (indieAuthResponse.has("profile")) {
@@ -619,6 +621,7 @@ public class AuthActivity extends AccountAuthenticatorActivity implements Volley
                             am.setUserData(account, "micropub_media_endpoint", micropubMediaEndpoint);
                             am.setUserData(account, "author_name", authorName);
                             am.setUserData(account, "author_avatar", authorAvatar);
+                            am.setUserData(account, "refresh_token", refreshToken);
 
                             // Set default account.
                             setDefaultAccount();
@@ -627,6 +630,7 @@ public class AuthActivity extends AccountAuthenticatorActivity implements Volley
                             User user = new User();
                             user.setMicropubEndpoint(micropubEndpoint);
                             user.setAccessToken(accessToken);
+                            user.setRefreshToken(refreshToken);
                             user.setAccount(account);
                             new MicropubAction(getApplicationContext(), user, layout).refreshConfig();
 

--- a/app/src/main/java/com/indieweb/indigenous/util/HTTPRequest.java
+++ b/app/src/main/java/com/indieweb/indigenous/util/HTTPRequest.java
@@ -1,6 +1,11 @@
 package com.indieweb.indigenous.util;
 
+import static com.indieweb.indigenous.users.AuthActivity.INDIEWEB_TOKEN_TYPE;
+
+import android.accounts.AccountManager;
 import android.content.Context;
+
+import com.android.volley.DefaultRetryPolicy;
 import com.android.volley.Request;
 import com.android.volley.RequestQueue;
 import com.android.volley.Response;
@@ -9,9 +14,133 @@ import com.android.volley.toolbox.StringRequest;
 import com.android.volley.toolbox.Volley;
 import com.indieweb.indigenous.R;
 import com.indieweb.indigenous.model.User;
+import com.indieweb.indigenous.users.AuthActivity;
+
+import org.json.JSONException;
+import org.json.JSONObject;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Semaphore;
+
+class TokenRefreshRequest extends StringRequest {
+    private final Context context;
+    private final User user;
+    private final Semaphore done;
+    private VolleyError failure;
+
+    TokenRefreshRequest(Context context, User user) {
+        super(Request.Method.POST, user.getTokenEndpoint(), null, null);
+        this.context = context;
+        this.user = user;
+        done = new Semaphore(0);
+        failure = null;
+    }
+
+    @Override
+    protected Map<String, String> getParams() {
+        Map<String, String> params = new HashMap<>();
+        params.put("client_id", AuthActivity.ClientId);
+        params.put("grant_type", "refresh_token");
+        params.put("refresh_token", user.getRefreshToken());
+        return params;
+    }
+
+    @Override
+    public Map<String, String> getHeaders() {
+        HashMap<String, String> headers = new HashMap<>();
+        headers.put("Accept", "application/json");
+        return headers;
+    }
+
+    @Override
+    protected void deliverResponse(String response) {
+         try {
+            JSONObject refreshTokenResponse = new JSONObject(response);
+
+            AccountManager am = AccountManager.get(context);
+
+            String accessToken = refreshTokenResponse.optString("access_token");
+            if (!accessToken.isEmpty()) {
+                user.setAccessToken(accessToken);
+                am.setAuthToken(user.getAccount(), INDIEWEB_TOKEN_TYPE, accessToken);
+            }
+
+            String refreshToken = refreshTokenResponse.optString("refresh_token");
+            if (!refreshToken.isEmpty()) {
+                user.setRefreshToken(refreshToken);
+                am.setUserData(user.getAccount(), "refresh_token", refreshToken);
+            }
+
+        } catch (JSONException e) {
+            failure = new VolleyError(e);
+        }
+        done.release();
+    }
+
+    @Override
+    public void deliverError(VolleyError error) {
+        failure = error;
+        done.release();
+    }
+
+    public VolleyError await() throws InterruptedException {
+        done.acquire();
+        return failure;
+    }
+}
+
+class TokenRetryPolicy extends DefaultRetryPolicy {
+    private final Context context;
+    private final RequestQueue queue;
+    private final User user;
+    private boolean retried;
+
+    TokenRetryPolicy(Context context, RequestQueue queue, User user) {
+        this.context = context;
+        this.queue = queue;
+        this.user = user;
+        retried = false;
+    }
+
+    @Override
+    protected boolean hasAttemptRemaining() {
+        return !retried;
+    }
+
+    @Override
+    public void retry(VolleyError error) throws VolleyError {
+        if (!hasAttemptRemaining()) {
+            throw error;
+        }
+
+        String hdr = error.networkResponse.headers.get("WWW-Authenticate");
+        if (hdr.contains("invalid-token")) {
+            // Our access token has expired. Do we have a refresh token? If so, try to use it.
+
+            String refreshToken = user.getRefreshToken();
+            if (refreshToken != null && !refreshToken.isEmpty()) {
+                TokenRefreshRequest req = new TokenRefreshRequest(context, user);
+                queue.add(req);
+                VolleyError failure;
+                try {
+                    failure = req.await();
+                } catch(InterruptedException e) {
+                    failure = new VolleyError(e);
+                }
+                if (failure != null) {
+                    throw failure;
+                }
+                retried = true;
+                return;
+            }
+
+            // We don't have a refresh token. For now, just fail.
+            // TODO: Restart the OAuth2 flow to get a new token.
+        }
+        throw error;
+    }
+}
 
 public class HTTPRequest {
 
@@ -67,6 +196,7 @@ public class HTTPRequest {
         };
 
         RequestQueue queue = Volley.newRequestQueue(context);
+        request.setRetryPolicy(new TokenRetryPolicy(context, queue, user));
         queue.add(request);
     }
 
@@ -114,6 +244,7 @@ public class HTTPRequest {
         };
 
         RequestQueue queue = Volley.newRequestQueue(context);
+        request.setRetryPolicy(new TokenRetryPolicy(context, queue, user));
         queue.add(request);
     }
 
@@ -161,6 +292,7 @@ public class HTTPRequest {
         };
 
         RequestQueue queue = Volley.newRequestQueue(context);
+        request.setRetryPolicy(new TokenRetryPolicy(context, queue, user));
         queue.add(request);
     }
 }


### PR DESCRIPTION
I made a crude start on #447. It roughly "Works For Me (TM)", but it has some problems:

* It only knows about IndieAuth. It doesn't support any of the other auth methods. This should be fixed; Mastodon is planning to add refresh tokens (https://github.com/mastodon/mastodon/issues/26838, https://github.com/mastodon/mastodon/pull/27948) though it probably won't happen quickly.
* If there's no `refresh_token` then ideally we should send the user back through the OAuth flow from the beginning. I started looking at this, but this will mean rearranging AuthActivity.java so that the flow can be started by triggering an intent or something, rather than only when the user clicks on the "Sign In" button.
* Calling into AccountManager from HTTPRequest.java feels like a bit of a layering violation. Is there a clearer way to structure things without too much refactoring?
* We could save a round-trip in many situations by paying attention to the token's `expires_in` value and refreshing automatically when we know it's expired, rather than relying on the server to tell us when we need to refresh.
* Applying the new `TokenRetryPolicy` to the requests that `AuthActivity.java` issues feels kind of circular. I don't _think_ this will break anything, but I'm not entirely certain.
